### PR TITLE
Deck rework

### DIFF
--- a/Karty/Components/Deck.cs
+++ b/Karty/Components/Deck.cs
@@ -37,7 +37,36 @@ namespace UNO
         /// </summary>
         public static void Shuffle()
         {
+            // Makes a duplicate of cards to keep track of unshuffled cards
+            List<Card> unshuffled = new List<Card>();
+            unshuffled.AddRange(cards);
 
+            // Card being transfered to new pile
+            Card focus_card = null;
+
+            // Index used for setting card z index, also can be used for current card count.
+            int current_index = 0;
+
+            // Reset the card collection
+            cards.Clear();
+
+            while(unshuffled.Count > 0)
+            {
+                // Get card to transfer
+                focus_card = unshuffled[r.Next(unshuffled.Count)];
+
+                // Set card to new Z index
+                focus_card.ZIndex = current_index;
+
+                // Add card to Deck
+                cards.Add(focus_card);
+
+                // Remove from unshuffled list
+                unshuffled.Remove(focus_card);
+                
+                // Increment for next index
+                current_index++;
+            }
         }
 
         /// <summary>
@@ -66,6 +95,9 @@ namespace UNO
                     CreateCard(color, i, ref current_index);
                 }
             }
+
+            // Shuffle new collection of cards
+            Shuffle();
         }
 
         private static void CreateCard(Color color, int number, ref int index)

--- a/Karty/Components/Deck.cs
+++ b/Karty/Components/Deck.cs
@@ -13,25 +13,19 @@ namespace UNO
     /// </summary>
     class Deck
     {
-        /// <summary>
-        /// Translation - Red colour. Globally used for all red cards.
-        /// </summary>
-        public static Color red = Color.Red;
+        // Translation - Creates a new instance of the Random class.
+        static Random r = new Random();
 
         /// <summary>
-        /// Translation - Blue color. Globally used for all blue cards.
+        /// All light colors available in deck
         /// </summary>
-        public static Color blue = Color.Blue;
-
-        /// <summary>
-        /// Translation - Green color. Globally used for all green cards.
-        /// </summary>
-        public static Color green = Color.Green;
-
-        /// <summary>
-        /// Translation - Yellow. Globally used for all yellow cards.
-        /// </summary>
-        public static Color yellow = Color.Yellow;
+        public static List<Color> LightColors = new List<Color>() 
+        {
+            Color.Red, 
+            Color.Blue, 
+            Color.Green, 
+            Color.Yellow
+        };
 
         /// <summary>
         /// Translation - A collection of all the cards in the deck.
@@ -55,39 +49,48 @@ namespace UNO
             // Translation - Resets the card collection if it was previously filled
             cards.Clear();
 
-            // Translation - Creates a new instance of the Random class.
-            Random r = new Random();
+            // List of all possible colors
+            List<Color> colors = LightColors;
 
-            // Translation - The cycle repeats 108 times.
-            // According to the rules, the deck should contain exactly that many cards.
-            foreach (var i in Enumerable.Range(0, 108))
+            // Index used for setting card z index, also can be used for current card count.
+            int current_index = 0;
+
+            // Cycle through all possible colors
+            foreach (Color color in colors)
             {
-                // Translation - An array of all the possible colors a card can have.
-                // The auxiliary field serves us to easily generate random card colors.
-                Color[] colors = { red, blue, green, yellow };
-
-                // Translation - Creates a Card instance and chooses a random color and number from 0 to 7.
-                Card card = new Card(colors[r.Next(colors.Count())], r.Next(0, 7));
-
-                // Translation - Assigns a Z-Index to the card. This index tells us how close along the
-                // imaginary Z axis the card is towards the observer (player / user).
-                // The larger the Z-Index, the closer the card is to the observer.
-                // The Z-Index is important to know which card the user clicked on if there are multiple
-                // individual cards on top of each other - like in our game deck.
-                card.ZIndex = i;
-
-                // Translation - Turns all cards in the deck face down.
-                // The boolean parameter of the method ensures that the unwanted animation
-                // that would be seen at the start of the game is not performed.
-                card.Flip(true);
-
-                // Translation - Sets the rotation of the card from -180 to 180. Only a visual effect
-                // and a detail that does not affect the functionality of the game.
-                card.Rotation = r.Next(-180, 180);
-
-                // Translation - Finally, we add our card to the collection of all cards in the pack.
-                cards.Add(card);
+                // Cycle through 1 - 9
+                for (int i = 1; i < 10; i++)
+                {
+                    // Create two of each numbered card
+                    CreateCard(color, i, ref current_index);
+                    CreateCard(color, i, ref current_index);
+                }
             }
+        }
+
+        private static void CreateCard(Color color, int number, ref int index)
+        {
+            // Translation - Creates a Card instance and chooses a random color and number from 0 to 7.
+            Card card = new Card(color, number);
+
+            // Translation - Assigns a Z-Index to the card. This index tells us how close along the
+            // imaginary Z axis the card is towards the observer (player / user).
+            // The larger the Z-Index, the closer the card is to the observer.
+            // The Z-Index is important to know which card the user clicked on if there are multiple
+            // individual cards on top of each other - like in our game deck.
+            card.ZIndex = index;
+
+            // Translation - Turns all cards in the deck face down.
+            // The boolean parameter of the method ensures that the unwanted animation
+            // that would be seen at the start of the game is not performed.
+            card.Flip(true);
+
+            // Translation - Sets the rotation of the card from -180 to 180. Only a visual effect
+            // and a detail that does not affect the functionality of the game.
+            card.Rotation = r.Next(-180, 180);
+
+            // Translation - Finally, we add our card to the collection of all cards in the pack.
+            cards.Add(card);
         }
 
         /// <summary>

--- a/Karty/Components/Enemy.cs
+++ b/Karty/Components/Enemy.cs
@@ -200,11 +200,10 @@ namespace UNO
             // Tranlsation - Creates a new dictionary that will contain the number of individual cards from each suit
             Dictionary<Color, int> balance = new Dictionary<Color, int>();
 
-            // Translation - Fills the dictionary
-            balance.Add(Deck.red, hand.Where(item => item.Color == Deck.red).Count());
-            balance.Add(Deck.blue, hand.Where(item => item.Color == Deck.blue).Count());
-            balance.Add(Deck.green, hand.Where(item => item.Color == Deck.green).Count());
-            balance.Add(Deck.yellow, hand.Where(item => item.Color == Deck.yellow).Count());
+            foreach (Color color in Deck.LightColors)
+            {
+                balance.Add(color, hand.Where(c => c.Color == color).Count());
+            }
 
             // Translation - Sorts the dictionary by the number of individual colors in descending order. This means that there will be such a color at the top,
             // from which we have the most cards.


### PR DESCRIPTION
TLDR: Deck.Create now makes the correct amount of Number/Color cards and shuffles them into Deck.cards.

Deck's old Create method would create 108 new instances of cards ranging from completely random colors (red, blue, green, yellow) and completely random numbers (0-7) in any order and combination. This was a problem because in "UNO," there's specifications to how many of each card there should be. The new Create now preforms a for loop for color and a nested for loop for the number, allowing for the proper card amounts to be followed. Although Create was just able to be updated, CreateCard was made to spread out the work of Create and hopefully make Create a lot easier to follow. Then once Create is done it references another updated method, Shuffle, which will simply replace the Deck.cards in a new order. Minor changes made to Enemy.ChooseBestCard to find amount of available options when playing.